### PR TITLE
Implement JSON-RPC notification handling and improve HTTP transport r…

### DIFF
--- a/mcp/client.go
+++ b/mcp/client.go
@@ -74,6 +74,13 @@ func (c *Client) Initialize(ctx context.Context) (*InitializeResponse, error) {
 
 	c.capabilities = &initResult.Capabilities
 	c.initialized = true
+
+	// Per MCP spec: after receiving the initialize response, the client MUST
+	// send a notifications/initialized notification before any other requests.
+	if err := c.protocol.Notification("notifications/initialized", nil); err != nil {
+		return nil, errors.Wrap(err, "failed to send initialized notification")
+	}
+
 	return &initResult, nil
 }
 

--- a/mcp/transport/httptransport/http.go
+++ b/mcp/transport/httptransport/http.go
@@ -115,6 +115,11 @@ func (t *HTTPTransport) SetMessageHandler(handler func(ctx context.Context, mess
 	t.messageHandler = handler
 }
 
+// ServeHTTP implements http.Handler, allowing HTTPTransport to be used directly
+func (t *HTTPTransport) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	t.handleRequest(w, r)
+}
+
 func (t *HTTPTransport) handleRequest(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Only POST method is supported", http.StatusMethodNotAllowed)
@@ -134,6 +139,12 @@ func (t *HTTPTransport) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if response == nil {
+		// Notifications produce no response body; return 202 Accepted
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+
 	jsonData, err := json.Marshal(response)
 	if err != nil {
 		if t.errorHandler != nil {
@@ -149,87 +160,74 @@ func (t *HTTPTransport) handleRequest(w http.ResponseWriter, r *http.Request) {
 
 // handleMessage processes an incoming message and returns a response
 func (t *HTTPTransport) handleMessage(ctx context.Context, body []byte) (*transport.BaseJsonRpcMessage, error) {
-	// Store the response writer for later use
-	t.mu.Lock()
-
-	key := atomic.AddInt64(&t.atomicCounter, 1)
-	t.responseMap[key] = make(chan *transport.BaseJsonRpcMessage)
-	t.mu.Unlock()
-
-	var prevId *transport.RequestId = nil
-	deserialized := false
-	// Try to unmarshal as a request first
+	// Try to unmarshal as a request first (requests have an id field)
 	var request transport.BaseJSONRPCRequest
 	if err := json.Unmarshal(body, &request); err == nil {
-		deserialized = true
-		id := request.Id
-		prevId = &id
+		key := atomic.AddInt64(&t.atomicCounter, 1)
+		t.mu.Lock()
+		t.responseMap[key] = make(chan *transport.BaseJsonRpcMessage)
+		t.mu.Unlock()
+
+		prevId := request.Id
 		request.Id = transport.RequestId(key)
+
 		t.mu.RLock()
 		handler := t.messageHandler
 		t.mu.RUnlock()
-
 		if handler != nil {
 			handler(ctx, transport.NewBaseMessageRequest(&request))
 		}
+
+		// Block until the protocol layer sends the response via Send()
+		responseToUse := <-t.responseMap[key]
+		t.mu.Lock()
+		delete(t.responseMap, key)
+		t.mu.Unlock()
+
+		if responseToUse.JsonRpcResponse != nil {
+			responseToUse.JsonRpcResponse.Id = prevId
+		}
+		return responseToUse, nil
 	}
 
-	// Try as a notification
+	// Try as a notification (has method, no id)
 	var notification transport.BaseJSONRPCNotification
-	if !deserialized {
-		if err := json.Unmarshal(body, &notification); err == nil {
-			//deserialized = true
-			t.mu.RLock()
-			handler := t.messageHandler
-			t.mu.RUnlock()
-
-			if handler != nil {
-				handler(ctx, transport.NewBaseMessageNotification(&notification))
-			}
+	if err := json.Unmarshal(body, &notification); err == nil {
+		t.mu.RLock()
+		handler := t.messageHandler
+		t.mu.RUnlock()
+		if handler != nil {
+			handler(ctx, transport.NewBaseMessageNotification(&notification))
 		}
-		return &transport.BaseJsonRpcMessage{
-			Type: transport.BaseMessageTypeJSONRPCResponseType,
-		}, nil
+		// Notifications require no response body
+		return nil, nil
 	}
 
 	// Try as a response
 	var response transport.BaseJSONRPCResponse
-	if !deserialized {
-		if err := json.Unmarshal(body, &response); err == nil {
-			deserialized = true
-			t.mu.RLock()
-			handler := t.messageHandler
-			t.mu.RUnlock()
-
-			if handler != nil {
-				handler(ctx, transport.NewBaseMessageResponse(&response))
-			}
+	if err := json.Unmarshal(body, &response); err == nil {
+		t.mu.RLock()
+		handler := t.messageHandler
+		t.mu.RUnlock()
+		if handler != nil {
+			handler(ctx, transport.NewBaseMessageResponse(&response))
 		}
+		return nil, nil
 	}
 
-	// Try as an error
+	// Try as an error response
 	var errorResponse transport.BaseJSONRPCError
-	if !deserialized {
-		if err := json.Unmarshal(body, &errorResponse); err == nil {
-			//deserialized = true
-			t.mu.RLock()
-			handler := t.messageHandler
-			t.mu.RUnlock()
-
-			if handler != nil {
-				handler(ctx, transport.NewBaseMessageError(&errorResponse))
-			}
+	if err := json.Unmarshal(body, &errorResponse); err == nil {
+		t.mu.RLock()
+		handler := t.messageHandler
+		t.mu.RUnlock()
+		if handler != nil {
+			handler(ctx, transport.NewBaseMessageError(&errorResponse))
 		}
+		return nil, nil
 	}
 
-	// Block until the response is received
-	responseToUse := <-t.responseMap[key]
-	delete(t.responseMap, key)
-	if prevId != nil && responseToUse.JsonRpcResponse != nil {
-		responseToUse.JsonRpcResponse.Id = *prevId
-	}
-
-	return responseToUse, nil
+	return nil, nil
 }
 
 // readBody reads and returns the body from an io.Reader

--- a/mcp/transport/httptransport/http_client.go
+++ b/mcp/transport/httptransport/http_client.go
@@ -92,6 +92,11 @@ func (t *HTTPClientTransport) Send(ctx context.Context, message *transport.BaseJ
 		return errors.Wrap(err, "failed to read response")
 	}
 
+	if resp.StatusCode == http.StatusAccepted || resp.StatusCode == http.StatusNoContent {
+		// Notification acknowledged — no response body expected
+		return nil
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return errors.Errorf("server returned error: %s (status: %d)", string(body), resp.StatusCode)
 	}

--- a/mcp/transport/httptransport/http_test.go
+++ b/mcp/transport/httptransport/http_test.go
@@ -1,0 +1,639 @@
+package httptransport_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/effective-security/gogentic/mcp/transport"
+	"github.com/effective-security/gogentic/mcp/transport/httptransport"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func marshalRequest(t *testing.T, method string, id int, params any) []byte {
+	t.Helper()
+	p, _ := json.Marshal(params)
+	req := transport.BaseJSONRPCRequest{
+		Jsonrpc: "2.0",
+		Method:  method,
+		Id:      transport.RequestId(id),
+		Params:  p,
+	}
+	b, err := json.Marshal(req)
+	require.NoError(t, err)
+	return b
+}
+
+func marshalNotification(t *testing.T, method string, params any) []byte {
+	t.Helper()
+	p, _ := json.Marshal(params)
+	n := transport.BaseJSONRPCNotification{
+		Jsonrpc: "2.0",
+		Method:  method,
+		Params:  p,
+	}
+	b, err := json.Marshal(n)
+	require.NoError(t, err)
+	return b
+}
+
+// ---------------------------------------------------------------------------
+// HTTPTransport (server side) tests
+// ---------------------------------------------------------------------------
+
+func TestHTTPTransport_New(t *testing.T) {
+	tr := httptransport.NewHTTPTransport("/mcp")
+	assert.NotNil(t, tr)
+}
+
+func TestHTTPTransport_HandleRequest_NotPost(t *testing.T) {
+	tr := httptransport.NewHTTPTransport("/mcp")
+	tr.SetMessageHandler(func(_ context.Context, _ *transport.BaseJsonRpcMessage) {})
+
+	server := httptest.NewServer(tr)
+	defer server.Close()
+
+	resp, err := http.Get(server.URL + "/mcp")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+}
+
+func TestHTTPTransport_HandleRequest_Notification_Returns202(t *testing.T) {
+	tr := httptransport.NewHTTPTransport("/mcp")
+
+	var receivedMsg *transport.BaseJsonRpcMessage
+	tr.SetMessageHandler(func(_ context.Context, msg *transport.BaseJsonRpcMessage) {
+		receivedMsg = msg
+	})
+
+	server := httptest.NewServer(tr)
+	defer server.Close()
+
+	body := marshalNotification(t, "notifications/initialized", nil)
+	resp, err := http.Post(server.URL+"/mcp", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	respBody, _ := io.ReadAll(resp.Body)
+	assert.Empty(t, respBody)
+
+	require.NotNil(t, receivedMsg)
+	assert.Equal(t, transport.BaseMessageTypeJSONRPCNotificationType, receivedMsg.Type)
+	assert.Equal(t, "notifications/initialized", receivedMsg.JsonRpcNotification.Method)
+}
+
+func TestHTTPTransport_HandleRequest_NotificationWithParams(t *testing.T) {
+	tr := httptransport.NewHTTPTransport("/mcp")
+
+	var receivedMsg *transport.BaseJsonRpcMessage
+	tr.SetMessageHandler(func(_ context.Context, msg *transport.BaseJsonRpcMessage) {
+		receivedMsg = msg
+	})
+
+	server := httptest.NewServer(tr)
+	defer server.Close()
+
+	body := marshalNotification(t, "notifications/cancelled", map[string]any{"requestId": 1, "reason": "timeout"})
+	resp, err := http.Post(server.URL+"/mcp", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	require.NotNil(t, receivedMsg)
+	assert.Equal(t, transport.BaseMessageTypeJSONRPCNotificationType, receivedMsg.Type)
+	assert.NotEmpty(t, receivedMsg.JsonRpcNotification.Params)
+}
+
+func TestHTTPTransport_HandleRequest_RequestResponseRoundtrip(t *testing.T) {
+	tr := httptransport.NewHTTPTransport("/mcp")
+
+	tr.SetMessageHandler(func(ctx context.Context, msg *transport.BaseJsonRpcMessage) {
+		if msg.Type != transport.BaseMessageTypeJSONRPCRequestType {
+			return
+		}
+		// Send must be called from a separate goroutine — the protocol layer always
+		// dispatches handlers asynchronously, and handleMessage blocks on the receive
+		// until Send delivers the response.
+		go func() {
+			result, _ := json.Marshal(map[string]string{"echo": msg.JsonRpcRequest.Method})
+			_ = tr.Send(ctx, &transport.BaseJsonRpcMessage{
+				Type: transport.BaseMessageTypeJSONRPCResponseType,
+				JsonRpcResponse: &transport.BaseJSONRPCResponse{
+					Jsonrpc: "2.0",
+					Id:      msg.JsonRpcRequest.Id,
+					Result:  result,
+				},
+			})
+		}()
+	})
+
+	server := httptest.NewServer(tr)
+	defer server.Close()
+
+	body := marshalRequest(t, "tools/list", 42, nil)
+	resp, err := http.Post(server.URL+"/mcp", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var rpcResp transport.BaseJSONRPCResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&rpcResp))
+	assert.Equal(t, transport.RequestId(42), rpcResp.Id)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal(rpcResp.Result, &result))
+	assert.Equal(t, "tools/list", result["echo"])
+}
+
+func TestHTTPTransport_HandleRequest_OriginalIDRestored(t *testing.T) {
+	// The server internally remaps request IDs to an atomic counter for correlation;
+	// the original client-supplied ID must be restored in the response.
+	tr := httptransport.NewHTTPTransport("/mcp")
+
+	tr.SetMessageHandler(func(ctx context.Context, msg *transport.BaseJsonRpcMessage) {
+		if msg.Type != transport.BaseMessageTypeJSONRPCRequestType {
+			return
+		}
+		go func() {
+			_ = tr.Send(ctx, &transport.BaseJsonRpcMessage{
+				Type: transport.BaseMessageTypeJSONRPCResponseType,
+				JsonRpcResponse: &transport.BaseJSONRPCResponse{
+					Jsonrpc: "2.0",
+					Id:      msg.JsonRpcRequest.Id, // use the remapped (internal) id
+					Result:  []byte(`{}`),
+				},
+			})
+		}()
+	})
+
+	server := httptest.NewServer(tr)
+	defer server.Close()
+
+	const clientID = 999
+	body := marshalRequest(t, "ping", clientID, nil)
+	resp, err := http.Post(server.URL+"/mcp", "application/json", bytes.NewReader(body))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var rpcResp transport.BaseJSONRPCResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&rpcResp))
+	assert.Equal(t, transport.RequestId(clientID), rpcResp.Id)
+}
+
+func TestHTTPTransport_HandleRequest_InvalidJSON(t *testing.T) {
+	tr := httptransport.NewHTTPTransport("/mcp")
+
+	server := httptest.NewServer(tr)
+	defer server.Close()
+
+	resp, err := http.Post(server.URL+"/mcp", "application/json", bytes.NewReader([]byte("not json")))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	// Unrecognised body: no channel is created, so we get 202 (treated as no-op)
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+}
+
+func TestHTTPTransport_Send_NoChannelReturnsError(t *testing.T) {
+	tr := httptransport.NewHTTPTransport("/mcp")
+	err := tr.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCResponseType,
+		JsonRpcResponse: &transport.BaseJSONRPCResponse{
+			Jsonrpc: "2.0",
+			Id:      transport.RequestId(9999),
+			Result:  []byte(`{}`),
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no response channel found")
+}
+
+func TestHTTPTransport_Send_NotificationIsNoOp(t *testing.T) {
+	tr := httptransport.NewHTTPTransport("/mcp")
+	err := tr.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCNotificationType,
+		JsonRpcNotification: &transport.BaseJSONRPCNotification{
+			Jsonrpc: "2.0",
+			Method:  "notifications/tools/list_changed",
+		},
+	})
+	assert.NoError(t, err)
+}
+
+func TestHTTPTransport_Close(t *testing.T) {
+	tr := httptransport.NewHTTPTransport("/mcp")
+
+	closeCalled := false
+	tr.SetCloseHandler(func() { closeCalled = true })
+
+	// Close without a running server should not panic
+	require.NoError(t, tr.Close())
+	assert.True(t, closeCalled)
+}
+
+func TestHTTPTransport_SetErrorHandler(t *testing.T) {
+	tr := httptransport.NewHTTPTransport("/mcp")
+	var gotErr error
+	tr.SetErrorHandler(func(e error) { gotErr = e })
+
+	// Trigger an error by calling Send with an unknown key
+	_ = tr.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCResponseType,
+		JsonRpcResponse: &transport.BaseJSONRPCResponse{
+			Id: transport.RequestId(1),
+		},
+	})
+	// Error is returned directly from Send, not through the error handler
+	assert.Nil(t, gotErr)
+}
+
+func TestHTTPTransport_AllMCPNotificationsReturn202(t *testing.T) {
+	notifications := []string{
+		"notifications/initialized",
+		"notifications/cancelled",
+		"notifications/tools/list_changed",
+		"notifications/prompts/list_changed",
+		"notifications/resources/list_changed",
+	}
+
+	for _, method := range notifications {
+		t.Run(method, func(t *testing.T) {
+			tr := httptransport.NewHTTPTransport("/mcp")
+			tr.SetMessageHandler(func(_ context.Context, _ *transport.BaseJsonRpcMessage) {})
+
+			server := httptest.NewServer(tr)
+			defer server.Close()
+
+			body := marshalNotification(t, method, nil)
+			resp, err := http.Post(server.URL+"/mcp", "application/json", bytes.NewReader(body))
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTPClientTransport (client side) tests
+// ---------------------------------------------------------------------------
+
+func TestHTTPClientTransport_New(t *testing.T) {
+	tr := httptransport.NewHTTPClientTransport("/mcp")
+	assert.NotNil(t, tr)
+}
+
+func TestHTTPClientTransport_Start_IsNoOp(t *testing.T) {
+	tr := httptransport.NewHTTPClientTransport("/mcp")
+	err := tr.Start(context.Background())
+	assert.NoError(t, err)
+}
+
+func TestHTTPClientTransport_Send_Request_ReceivesResponse(t *testing.T) {
+	// Fake server that returns a JSON-RPC response for any POST
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req transport.BaseJSONRPCRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+
+		result, _ := json.Marshal(map[string]string{"status": "ok"})
+		resp := transport.BaseJSONRPCResponse{
+			Jsonrpc: "2.0",
+			Id:      req.Id,
+			Result:  result,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	tr := httptransport.NewHTTPClientTransport("/mcp").WithBaseURL(srv.URL)
+
+	var receivedMsg *transport.BaseJsonRpcMessage
+	tr.SetMessageHandler(func(_ context.Context, msg *transport.BaseJsonRpcMessage) {
+		receivedMsg = msg
+	})
+
+	err := tr.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCRequestType,
+		JsonRpcRequest: &transport.BaseJSONRPCRequest{
+			Jsonrpc: "2.0",
+			Method:  "tools/list",
+			Id:      transport.RequestId(1),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, receivedMsg)
+	assert.Equal(t, transport.BaseMessageTypeJSONRPCResponseType, receivedMsg.Type)
+	assert.Equal(t, transport.RequestId(1), receivedMsg.JsonRpcResponse.Id)
+}
+
+func TestHTTPClientTransport_Send_Notification_Receives202(t *testing.T) {
+	// Server that returns 202 for notifications (correct server behaviour after our fix)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+
+	tr := httptransport.NewHTTPClientTransport("/mcp").WithBaseURL(srv.URL)
+
+	var receivedMsg *transport.BaseJsonRpcMessage
+	tr.SetMessageHandler(func(_ context.Context, msg *transport.BaseJsonRpcMessage) {
+		receivedMsg = msg
+	})
+
+	err := tr.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCNotificationType,
+		JsonRpcNotification: &transport.BaseJSONRPCNotification{
+			Jsonrpc: "2.0",
+			Method:  "notifications/initialized",
+		},
+	})
+	require.NoError(t, err)
+	// 202 Accepted → client should not dispatch any message
+	assert.Nil(t, receivedMsg)
+}
+
+func TestHTTPClientTransport_Send_Notification_Receives204(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	tr := httptransport.NewHTTPClientTransport("/mcp").WithBaseURL(srv.URL)
+
+	err := tr.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCNotificationType,
+		JsonRpcNotification: &transport.BaseJSONRPCNotification{
+			Jsonrpc: "2.0",
+			Method:  "notifications/initialized",
+		},
+	})
+	assert.NoError(t, err)
+}
+
+func TestHTTPClientTransport_Send_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	tr := httptransport.NewHTTPClientTransport("/mcp").WithBaseURL(srv.URL)
+	err := tr.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCRequestType,
+		JsonRpcRequest: &transport.BaseJSONRPCRequest{
+			Jsonrpc: "2.0",
+			Method:  "ping",
+			Id:      transport.RequestId(1),
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestHTTPClientTransport_Send_ReceivesErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		errResp := transport.BaseJSONRPCError{
+			Jsonrpc: "2.0",
+			Id:      transport.RequestId(1),
+			Error: transport.BaseJSONRPCErrorInner{
+				Code:    -32601,
+				Message: "method not found",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(errResp)
+	}))
+	defer srv.Close()
+
+	tr := httptransport.NewHTTPClientTransport("/mcp").WithBaseURL(srv.URL)
+
+	var receivedMsg *transport.BaseJsonRpcMessage
+	tr.SetMessageHandler(func(_ context.Context, msg *transport.BaseJsonRpcMessage) {
+		receivedMsg = msg
+	})
+
+	err := tr.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCRequestType,
+		JsonRpcRequest: &transport.BaseJSONRPCRequest{
+			Jsonrpc: "2.0",
+			Method:  "unknown/method",
+			Id:      transport.RequestId(1),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, receivedMsg)
+	assert.Equal(t, transport.BaseMessageTypeJSONRPCErrorType, receivedMsg.Type)
+	assert.Equal(t, -32601, receivedMsg.JsonRpcError.Error.Code)
+	assert.Equal(t, "method not found", receivedMsg.JsonRpcError.Error.Message)
+}
+
+func TestHTTPClientTransport_Send_EmptyResponseBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Write nothing
+	}))
+	defer srv.Close()
+
+	tr := httptransport.NewHTTPClientTransport("/mcp").WithBaseURL(srv.URL)
+
+	var receivedMsg *transport.BaseJsonRpcMessage
+	tr.SetMessageHandler(func(_ context.Context, msg *transport.BaseJsonRpcMessage) {
+		receivedMsg = msg
+	})
+
+	err := tr.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCRequestType,
+		JsonRpcRequest: &transport.BaseJSONRPCRequest{
+			Jsonrpc: "2.0",
+			Method:  "ping",
+			Id:      transport.RequestId(1),
+		},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, receivedMsg)
+}
+
+func TestHTTPClientTransport_WithCustomClient(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		result, _ := json.Marshal(map[string]string{"ok": "true"})
+		resp := transport.BaseJSONRPCResponse{Jsonrpc: "2.0", Id: 1, Result: result}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	tr := httptransport.NewHTTPClientTransport("/mcp").
+		WithBaseURL(srv.URL).
+		WithClient(srv.Client()) // inject test client
+
+	err := tr.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCRequestType,
+		JsonRpcRequest: &transport.BaseJSONRPCRequest{
+			Jsonrpc: "2.0",
+			Method:  "ping",
+			Id:      transport.RequestId(1),
+		},
+	})
+	assert.NoError(t, err)
+}
+
+func TestHTTPClientTransport_WithHeaders(t *testing.T) {
+	var receivedHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeader = r.Header.Get("X-Api-Key")
+		result, _ := json.Marshal(map[string]string{})
+		resp := transport.BaseJSONRPCResponse{Jsonrpc: "2.0", Id: 1, Result: result}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer srv.Close()
+
+	tr := httptransport.NewHTTPClientTransport("/mcp").
+		WithBaseURL(srv.URL).
+		WithHeader("X-Api-Key", "secret")
+
+	_ = tr.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type:           transport.BaseMessageTypeJSONRPCRequestType,
+		JsonRpcRequest: &transport.BaseJSONRPCRequest{Jsonrpc: "2.0", Method: "ping", Id: 1},
+	})
+	assert.Equal(t, "secret", receivedHeader)
+}
+
+func TestHTTPClientTransport_Close(t *testing.T) {
+	tr := httptransport.NewHTTPClientTransport("/mcp")
+
+	closeCalled := false
+	tr.SetCloseHandler(func() { closeCalled = true })
+
+	require.NoError(t, tr.Close())
+	assert.True(t, closeCalled)
+}
+
+// ---------------------------------------------------------------------------
+// Integration: server + client paired together
+// ---------------------------------------------------------------------------
+
+func TestHTTPTransport_Integration_RequestResponse(t *testing.T) {
+	// Wire up a real HTTPTransport server and an HTTPClientTransport client.
+	serverTransport := httptransport.NewHTTPTransport("/mcp")
+
+	serverTransport.SetMessageHandler(func(ctx context.Context, msg *transport.BaseJsonRpcMessage) {
+		if msg.Type != transport.BaseMessageTypeJSONRPCRequestType {
+			return
+		}
+		go func() {
+			result, _ := json.Marshal(map[string]string{"reply": "pong"})
+			_ = serverTransport.Send(ctx, &transport.BaseJsonRpcMessage{
+				Type: transport.BaseMessageTypeJSONRPCResponseType,
+				JsonRpcResponse: &transport.BaseJSONRPCResponse{
+					Jsonrpc: "2.0",
+					Id:      msg.JsonRpcRequest.Id,
+					Result:  result,
+				},
+			})
+		}()
+	})
+
+	srv := httptest.NewServer(serverTransport)
+	defer srv.Close()
+
+	clientTransport := httptransport.NewHTTPClientTransport("/mcp").WithBaseURL(srv.URL)
+	require.NoError(t, clientTransport.Start(context.Background()))
+
+	var clientReceived *transport.BaseJsonRpcMessage
+	clientTransport.SetMessageHandler(func(_ context.Context, msg *transport.BaseJsonRpcMessage) {
+		clientReceived = msg
+	})
+
+	err := clientTransport.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCRequestType,
+		JsonRpcRequest: &transport.BaseJSONRPCRequest{
+			Jsonrpc: "2.0",
+			Method:  "ping",
+			Id:      transport.RequestId(7),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, clientReceived)
+	assert.Equal(t, transport.BaseMessageTypeJSONRPCResponseType, clientReceived.Type)
+	assert.Equal(t, transport.RequestId(7), clientReceived.JsonRpcResponse.Id)
+
+	var result map[string]string
+	require.NoError(t, json.Unmarshal(clientReceived.JsonRpcResponse.Result, &result))
+	assert.Equal(t, "pong", result["reply"])
+}
+
+func TestHTTPTransport_Integration_NotificationFlow(t *testing.T) {
+	// After an initialize exchange, the client sends notifications/initialized.
+	// The server must accept it (202) without crashing.
+	serverTransport := httptransport.NewHTTPTransport("/mcp")
+
+	var notificationReceived bool
+	serverTransport.SetMessageHandler(func(ctx context.Context, msg *transport.BaseJsonRpcMessage) {
+		switch msg.Type {
+		case transport.BaseMessageTypeJSONRPCRequestType:
+			go func() {
+				result, _ := json.Marshal(map[string]any{
+					"protocolVersion": "2025-06-18",
+					"capabilities":    map[string]any{},
+					"serverInfo":      map[string]string{"name": "test", "version": "1"},
+				})
+				_ = serverTransport.Send(ctx, &transport.BaseJsonRpcMessage{
+					Type: transport.BaseMessageTypeJSONRPCResponseType,
+					JsonRpcResponse: &transport.BaseJSONRPCResponse{
+						Jsonrpc: "2.0",
+						Id:      msg.JsonRpcRequest.Id,
+						Result:  result,
+					},
+				})
+			}()
+		case transport.BaseMessageTypeJSONRPCNotificationType:
+			if msg.JsonRpcNotification.Method == "notifications/initialized" {
+				notificationReceived = true
+			}
+		}
+	})
+
+	srv := httptest.NewServer(serverTransport)
+	defer srv.Close()
+
+	clientTransport := httptransport.NewHTTPClientTransport("/mcp").WithBaseURL(srv.URL)
+	clientTransport.SetMessageHandler(func(_ context.Context, _ *transport.BaseJsonRpcMessage) {})
+
+	// Step 1: initialize request
+	err := clientTransport.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCRequestType,
+		JsonRpcRequest: &transport.BaseJSONRPCRequest{
+			Jsonrpc: "2.0",
+			Method:  "initialize",
+			Id:      transport.RequestId(1),
+		},
+	})
+	require.NoError(t, err)
+
+	// Step 2: notifications/initialized — must not error
+	err = clientTransport.Send(context.Background(), &transport.BaseJsonRpcMessage{
+		Type: transport.BaseMessageTypeJSONRPCNotificationType,
+		JsonRpcNotification: &transport.BaseJSONRPCNotification{
+			Jsonrpc: "2.0",
+			Method:  "notifications/initialized",
+		},
+	})
+	require.NoError(t, err)
+
+	// Give the server handler goroutine a moment to process
+	time.Sleep(5 * time.Millisecond)
+	assert.True(t, notificationReceived)
+}

--- a/mcp/transport/localtransport/local.go
+++ b/mcp/transport/localtransport/local.go
@@ -97,92 +97,76 @@ func (s *Transport) Send(ctx context.Context, message *transport.BaseJsonRpcMess
 
 // HandleMessage processes an incoming message and returns a response
 func (s *Transport) HandleMessage(ctx context.Context, body []byte) (*transport.BaseJsonRpcMessage, error) {
-	key := atomic.AddInt64(&s.atomicCounter, 1)
-	// Store the response writer for later use
-	s.mu.Lock()
-	s.responseMap[key] = make(chan *transport.BaseJsonRpcMessage)
-	s.mu.Unlock()
-
-	var prevId *transport.RequestId = nil
-	deserialized := false
-	// Try to unmarshal as a request first
+	// Try to unmarshal as a request first (requests have an id field)
 	var request transport.BaseJSONRPCRequest
 	if err := json.Unmarshal(body, &request); err == nil {
-		deserialized = true
-		id := request.Id
-		prevId = &id
+		key := atomic.AddInt64(&s.atomicCounter, 1)
+		s.mu.Lock()
+		s.responseMap[key] = make(chan *transport.BaseJsonRpcMessage)
+		s.mu.Unlock()
+
+		prevId := request.Id
 		request.Id = transport.RequestId(key)
+
 		s.mu.RLock()
 		handler := s.messageHandler
 		s.mu.RUnlock()
-
 		if handler != nil {
 			handler(ctx, transport.NewBaseMessageRequest(&request))
 		}
+
+		// Block until the protocol layer sends the response via Send()
+		s.mu.RLock()
+		ch := s.responseMap[key]
+		s.mu.RUnlock()
+
+		responseToUse := <-ch
+
+		s.mu.Lock()
+		delete(s.responseMap, key)
+		s.mu.Unlock()
+
+		if responseToUse.JsonRpcResponse != nil {
+			responseToUse.JsonRpcResponse.Id = prevId
+		}
+		return responseToUse, nil
 	}
 
-	// Try as a notification
+	// Try as a notification (has method, no id)
 	var notification transport.BaseJSONRPCNotification
-	if !deserialized {
-		if err := json.Unmarshal(body, &notification); err == nil {
-			//deserialized = true
-			s.mu.RLock()
-			handler := s.messageHandler
-			s.mu.RUnlock()
-
-			if handler != nil {
-				handler(ctx, transport.NewBaseMessageNotification(&notification))
-			}
+	if err := json.Unmarshal(body, &notification); err == nil {
+		s.mu.RLock()
+		handler := s.messageHandler
+		s.mu.RUnlock()
+		if handler != nil {
+			handler(ctx, transport.NewBaseMessageNotification(&notification))
 		}
-		return &transport.BaseJsonRpcMessage{
-			Type: transport.BaseMessageTypeJSONRPCResponseType,
-		}, nil
+		return nil, nil
 	}
 
 	// Try as a response
 	var response transport.BaseJSONRPCResponse
-	if !deserialized {
-		if err := json.Unmarshal(body, &response); err == nil {
-			deserialized = true
-			s.mu.RLock()
-			handler := s.messageHandler
-			s.mu.RUnlock()
-
-			if handler != nil {
-				handler(ctx, transport.NewBaseMessageResponse(&response))
-			}
+	if err := json.Unmarshal(body, &response); err == nil {
+		s.mu.RLock()
+		handler := s.messageHandler
+		s.mu.RUnlock()
+		if handler != nil {
+			handler(ctx, transport.NewBaseMessageResponse(&response))
 		}
+		return nil, nil
 	}
 
-	// Try as an error
+	// Try as an error response
 	var errorResponse transport.BaseJSONRPCError
-	if !deserialized {
-		if err := json.Unmarshal(body, &errorResponse); err == nil {
-			//deserialized = true
-			s.mu.RLock()
-			handler := s.messageHandler
-			s.mu.RUnlock()
-
-			if handler != nil {
-				handler(ctx, transport.NewBaseMessageError(&errorResponse))
-			}
+	if err := json.Unmarshal(body, &errorResponse); err == nil {
+		s.mu.RLock()
+		handler := s.messageHandler
+		s.mu.RUnlock()
+		if handler != nil {
+			handler(ctx, transport.NewBaseMessageError(&errorResponse))
 		}
+		return nil, nil
 	}
 
-	// Block until the response is received
-	s.mu.RLock()
-	ch := s.responseMap[key]
-	s.mu.RUnlock()
-
-	responseToUse := <-ch
-
-	s.mu.Lock()
-	delete(s.responseMap, key)
-	s.mu.Unlock()
-
-	if prevId != nil && responseToUse.JsonRpcResponse != nil {
-		responseToUse.JsonRpcResponse.Id = *prevId
-	}
-
-	return responseToUse, nil
+	return nil, nil
 }

--- a/mcp/transport/localtransport/local_test.go
+++ b/mcp/transport/localtransport/local_test.go
@@ -374,8 +374,7 @@ func TestTransport_HandleMessage(t *testing.T) {
 		require.NoError(t, err)
 		response, err := tr.HandleMessage(context.Background(), notificationBody)
 		require.NoError(t, err)
-		require.NotNil(t, response)
-		assert.Equal(t, transport.BaseMessageTypeJSONRPCResponseType, response.Type)
+		assert.Nil(t, response)
 		require.NotNil(t, receivedMessage)
 		assert.Equal(t, transport.BaseMessageTypeJSONRPCNotificationType, receivedMessage.Type)
 		assert.Equal(t, "test_notification", receivedMessage.JsonRpcNotification.Method)
@@ -398,10 +397,9 @@ func TestTransport_HandleMessage(t *testing.T) {
 
 		result, err := tr.HandleMessage(context.Background(), responseBody)
 		require.NoError(t, err)
-		require.NotNil(t, result)
-		// The message handler is not called for responses (based on the code logic)
-		// So receivedMessage should be nil
-		assert.Nil(t, receivedMessage)
+		assert.Nil(t, result)
+		require.NotNil(t, receivedMessage)
+		assert.Equal(t, transport.BaseMessageTypeJSONRPCResponseType, receivedMessage.Type)
 	})
 
 	t.Run("handle JSON-RPC error", func(t *testing.T) {
@@ -423,10 +421,9 @@ func TestTransport_HandleMessage(t *testing.T) {
 
 		result, err := tr.HandleMessage(context.Background(), errorBody)
 		require.NoError(t, err)
-		require.NotNil(t, result)
-		// The message handler is not called for errors (based on the code logic)
-		// So receivedMessage should be nil
-		assert.Nil(t, receivedMessage)
+		assert.Nil(t, result)
+		require.NotNil(t, receivedMessage)
+		assert.Equal(t, transport.BaseMessageTypeJSONRPCErrorType, receivedMessage.Type)
 	})
 
 	t.Run("handle invalid JSON", func(t *testing.T) {

--- a/mcp/transport/sse/internal/sse/sse.go
+++ b/mcp/transport/sse/internal/sse/sse.go
@@ -150,14 +150,27 @@ func (t *SSETransport) HandleMessage(msg []byte) error {
 	var jsonrpcMsg *transport.BaseJsonRpcMessage
 
 	if _, ok := rpcMsg["method"]; ok {
-		var req transport.BaseJSONRPCRequest
-		if err := json.Unmarshal(msg, &req); err != nil {
-			if t.errorHandler != nil {
-				t.errorHandler(err)
+		if _, hasID := rpcMsg["id"]; hasID {
+			// Has both method and id: it's a request
+			var req transport.BaseJSONRPCRequest
+			if err := json.Unmarshal(msg, &req); err != nil {
+				if t.errorHandler != nil {
+					t.errorHandler(err)
+				}
+				return err
 			}
-			return err
+			jsonrpcMsg = transport.NewBaseMessageRequest(&req)
+		} else {
+			// Has method but no id: it's a notification
+			var notification transport.BaseJSONRPCNotification
+			if err := json.Unmarshal(msg, &notification); err != nil {
+				if t.errorHandler != nil {
+					t.errorHandler(err)
+				}
+				return err
+			}
+			jsonrpcMsg = transport.NewBaseMessageNotification(&notification)
 		}
-		jsonrpcMsg = transport.NewBaseMessageRequest(&req)
 	} else {
 		var resp transport.BaseJSONRPCResponse
 		if err := json.Unmarshal(msg, &resp); err != nil {

--- a/mcp/transport/sse/internal/sse/sse_test.go
+++ b/mcp/transport/sse/internal/sse/sse_test.go
@@ -2,10 +2,12 @@ package sse_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/effective-security/gogentic/mcp/transport"
 	"github.com/effective-security/gogentic/mcp/transport/sse/internal/sse"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,6 +134,117 @@ func TestSSETransport_HandleMessage(t *testing.T) {
 		require.NoError(t, err)
 		err = transport.HandleMessage(nil)
 		assert.Error(t, err)
+	})
+
+	t.Run("notification without id is dispatched correctly", func(t *testing.T) {
+		w := newMockResponseWriter()
+		tr, err := sse.NewSSETransport("/messages", w)
+		require.NoError(t, err)
+
+		var receivedMessage *transport.BaseJsonRpcMessage
+		tr.SetMessageHandler(func(msg *transport.BaseJsonRpcMessage) {
+			receivedMessage = msg
+		})
+		var receivedError error
+		tr.SetErrorHandler(func(e error) { receivedError = e })
+
+		notification := transport.BaseJSONRPCNotification{
+			Jsonrpc: "2.0",
+			Method:  "notifications/initialized",
+		}
+		body, err := json.Marshal(notification)
+		require.NoError(t, err)
+
+		err = tr.HandleMessage(body)
+		require.NoError(t, err)
+		assert.Nil(t, receivedError, "no error expected for a valid notification")
+		require.NotNil(t, receivedMessage)
+		assert.Equal(t, transport.BaseMessageTypeJSONRPCNotificationType, receivedMessage.Type)
+		assert.Equal(t, "notifications/initialized", receivedMessage.JsonRpcNotification.Method)
+	})
+
+	t.Run("notification with params", func(t *testing.T) {
+		w := newMockResponseWriter()
+		tr, err := sse.NewSSETransport("/messages", w)
+		require.NoError(t, err)
+
+		var receivedMessage *transport.BaseJsonRpcMessage
+		tr.SetMessageHandler(func(msg *transport.BaseJsonRpcMessage) { receivedMessage = msg })
+
+		params, _ := json.Marshal(map[string]any{"key": "value"})
+		notification := transport.BaseJSONRPCNotification{
+			Jsonrpc: "2.0",
+			Method:  "notifications/tools/list_changed",
+			Params:  params,
+		}
+		body, err := json.Marshal(notification)
+		require.NoError(t, err)
+
+		err = tr.HandleMessage(body)
+		require.NoError(t, err)
+		require.NotNil(t, receivedMessage)
+		assert.Equal(t, transport.BaseMessageTypeJSONRPCNotificationType, receivedMessage.Type)
+		assert.Equal(t, "notifications/tools/list_changed", receivedMessage.JsonRpcNotification.Method)
+		assert.NotEmpty(t, receivedMessage.JsonRpcNotification.Params)
+	})
+
+	t.Run("request with id is dispatched as request", func(t *testing.T) {
+		w := newMockResponseWriter()
+		tr, err := sse.NewSSETransport("/messages", w)
+		require.NoError(t, err)
+
+		var receivedMessage *transport.BaseJsonRpcMessage
+		tr.SetMessageHandler(func(msg *transport.BaseJsonRpcMessage) { receivedMessage = msg })
+
+		request := transport.BaseJSONRPCRequest{
+			Jsonrpc: "2.0",
+			Method:  "initialize",
+			Id:      transport.RequestId(1),
+		}
+		body, err := json.Marshal(request)
+		require.NoError(t, err)
+
+		err = tr.HandleMessage(body)
+		require.NoError(t, err)
+		require.NotNil(t, receivedMessage)
+		assert.Equal(t, transport.BaseMessageTypeJSONRPCRequestType, receivedMessage.Type)
+		assert.Equal(t, "initialize", receivedMessage.JsonRpcRequest.Method)
+		assert.Equal(t, transport.RequestId(1), receivedMessage.JsonRpcRequest.Id)
+	})
+
+	t.Run("all standard MCP notifications are dispatched without error", func(t *testing.T) {
+		mcpNotifications := []string{
+			"notifications/initialized",
+			"notifications/cancelled",
+			"notifications/tools/list_changed",
+			"notifications/prompts/list_changed",
+			"notifications/resources/list_changed",
+			"$/progress",
+		}
+
+		for _, method := range mcpNotifications {
+			t.Run(method, func(t *testing.T) {
+				w := newMockResponseWriter()
+				tr, err := sse.NewSSETransport("/messages", w)
+				require.NoError(t, err)
+
+				var receivedMessage *transport.BaseJsonRpcMessage
+				tr.SetMessageHandler(func(msg *transport.BaseJsonRpcMessage) { receivedMessage = msg })
+				var receivedError error
+				tr.SetErrorHandler(func(e error) { receivedError = e })
+
+				body, _ := json.Marshal(map[string]any{
+					"jsonrpc": "2.0",
+					"method":  method,
+				})
+				err = tr.HandleMessage(body)
+				require.NoError(t, err)
+				assert.Nil(t, receivedError)
+				require.NotNil(t, receivedMessage)
+				assert.Equal(t, transport.BaseMessageTypeJSONRPCNotificationType, receivedMessage.Type)
+				assert.Equal(t, method, receivedMessage.JsonRpcNotification.Method)
+			})
+		}
 	})
 }
 

--- a/mcp/transport/sse/sse_server_test.go
+++ b/mcp/transport/sse/sse_server_test.go
@@ -129,6 +129,35 @@ func TestSSEServerTransport_HandlePostMessage(t *testing.T) {
 		assert.Equal(t, transport.RequestId(123), receivedMessage.JsonRpcRequest.Id)
 	})
 
+	t.Run("successful JSON-RPC notification with params", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		sseTransport, err := sse.NewSSEServerTransport("/messages", w)
+		require.NoError(t, err)
+
+		var receivedMessage *transport.BaseJsonRpcMessage
+		sseTransport.SetMessageHandler(func(msg *transport.BaseJsonRpcMessage) {
+			receivedMessage = msg
+		})
+
+		params, _ := json.Marshal(map[string]any{"requestId": 1, "reason": "timeout"})
+		notification := transport.BaseJSONRPCNotification{
+			Jsonrpc: "2.0",
+			Method:  "notifications/cancelled",
+			Params:  params,
+		}
+		notificationBytes, err := json.Marshal(notification)
+		require.NoError(t, err)
+
+		httpReq := httptest.NewRequest(http.MethodPost, "/messages", bytes.NewReader(notificationBytes))
+		httpReq.Header.Set("Content-Type", "application/json")
+
+		err = sseTransport.HandlePostMessage(httpReq)
+		assert.NoError(t, err)
+		require.NotNil(t, receivedMessage)
+		assert.Equal(t, transport.BaseMessageTypeJSONRPCNotificationType, receivedMessage.Type)
+		assert.Equal(t, "notifications/cancelled", receivedMessage.JsonRpcNotification.Method)
+	})
+
 	t.Run("successful JSON-RPC response", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		sseTransport, err := sse.NewSSEServerTransport("/messages", w)

--- a/mcp/transport/types.go
+++ b/mcp/transport/types.go
@@ -99,9 +99,10 @@ type BaseJSONRPCNotification struct {
 // Requires a Jsonrpc and Method
 func (m *BaseJSONRPCNotification) UnmarshalJSON(data []byte) error {
 	required := struct {
-		Jsonrpc *string `json:"jsonrpc" yaml:"jsonrpc" mapstructure:"jsonrpc"`
-		Method  *string `json:"method" yaml:"method" mapstructure:"method"`
-		Id      *int64  `json:"id" yaml:"id" mapstructure:"id"`
+		Jsonrpc *string          `json:"jsonrpc" yaml:"jsonrpc" mapstructure:"jsonrpc"`
+		Method  *string          `json:"method" yaml:"method" mapstructure:"method"`
+		Id      *int64           `json:"id" yaml:"id" mapstructure:"id"`
+		Params  *json.RawMessage `json:"params" yaml:"params" mapstructure:"params"`
 	}{}
 	err := json.Unmarshal(data, &required)
 	if err != nil {
@@ -118,6 +119,9 @@ func (m *BaseJSONRPCNotification) UnmarshalJSON(data []byte) error {
 	}
 	m.Jsonrpc = *required.Jsonrpc
 	m.Method = *required.Method
+	if required.Params != nil {
+		m.Params = *required.Params
+	}
 	return nil
 }
 


### PR DESCRIPTION
…esponse management

- Added support for sending "notifications/initialized" after client initialization in `mcp/client.go`.
- Enhanced `BaseJSONRPCNotification` to include optional parameters in `mcp/transport/types.go`.
- Updated `HTTPClientTransport` to acknowledge notifications with a 202 status in `mcp/transport/httptransport/http_client.go`.
- Introduced tests for notification handling in HTTP transport and SSE transport, ensuring correct message dispatching and response behavior in `mcp/transport/httptransport/http_test.go` and `mcp/transport/sse/sse_server_test.go`.
- Refactored message handling logic to return nil for notifications in `mcp/transport/localtransport/local.go` and `mcp/transport/httptransport/http.go`.